### PR TITLE
Extend API to enable Multihost support

### DIFF
--- a/src/main/java/io/patriot_framework/network/simulator/api/builder/CalcRouteBuilder.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/builder/CalcRouteBuilder.java
@@ -161,7 +161,7 @@ public class CalcRouteBuilder {
     private Integer findNetworkByName(String name) {
         ArrayList<TopologyNetwork> topologyNetworks = topologyBuilder.getTopology().getNetworks();
         for (int i = 0; i < topologyNetworks.size(); i++) {
-            if (topologyNetworks.get(i).getName() == name) {
+            if (topologyNetworks.get(i).getName().equals(name)) {
                 return i;
             }
         }

--- a/src/main/java/io/patriot_framework/network/simulator/api/builder/NetworkBuilder.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/builder/NetworkBuilder.java
@@ -29,7 +29,7 @@ public class NetworkBuilder {
     /**
      * Creator of network (docker, VM, ...)
      */
-    private String creator;
+    private Object creator;
     private String ipAddress;
     private String name;
     private int mask = 0;
@@ -100,7 +100,7 @@ public class NetworkBuilder {
         return this;
     }
 
-    public NetworkBuilder withCreator(String creator) {
+    public NetworkBuilder withCreator(Object creator) {
         this.creator = creator;
         return this;
     }

--- a/src/main/java/io/patriot_framework/network/simulator/api/builder/RouterBuilder.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/builder/RouterBuilder.java
@@ -40,7 +40,7 @@ public class RouterBuilder {
     /**
      * Creator of object (docker, VM, ...)
      */
-    private String creator;
+    private Object creator;
 
     private Boolean corner = false;
 
@@ -64,7 +64,7 @@ public class RouterBuilder {
         return this;
     }
 
-    public RouterBuilder withCreator(String creator) {
+    public RouterBuilder withCreator(Object creator) {
         this.creator = creator;
         return this;
     }

--- a/src/main/java/io/patriot_framework/network/simulator/api/builder/TopologyBuilder.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/builder/TopologyBuilder.java
@@ -26,12 +26,12 @@ public class TopologyBuilder {
      * The Topology.
      */
     private Topology topology;
-    private String currentCreator;
+    private Object currentCreator;
 
-    public String getCurrentCreator() {
+    public Object getCurrentCreator() {
         return currentCreator;
     }
-    public TopologyBuilder withCreator(String creator) {
+    public TopologyBuilder withCreator(Object creator) {
         currentCreator = creator;
         return this;
     }
@@ -53,6 +53,10 @@ public class TopologyBuilder {
      */
     public TopologyBuilder(int networkCount) {
         topology = new Topology(networkCount);
+    }
+
+    public TopologyBuilder(Topology topology) {
+        this.topology = topology;
     }
 
     /**

--- a/src/main/java/io/patriot_framework/network/simulator/api/control/Controller.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/control/Controller.java
@@ -20,7 +20,9 @@ import io.patriot_framework.network.simulator.api.model.devices.Device;
 import io.patriot_framework.network.simulator.api.model.network.Network;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -157,7 +159,7 @@ public interface Controller {
      * Returns String identifier of controller, Docker/Rocket/VM, ...
      * @return identifier
      */
-    String getIdentifier();
+    Object getIdentifier();
 
     /**
      * Executes command in device.
@@ -165,6 +167,13 @@ public interface Controller {
      * @param command which will be executed
      */
     void executeCommand(Device device, String command);
+
+    /**
+     * If the controller consists of multiple controllers, return them
+     */
+    default Optional<Collection<Controller>> getSubControllers() {
+        return Optional.empty();
+    }
 
     /**
      * Starts device.

--- a/src/main/java/io/patriot_framework/network/simulator/api/manager/Manager.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/manager/Manager.java
@@ -474,10 +474,13 @@ public class Manager {
      * @return
      */
     private Controller findController(EnvironmentPart environmentPart) {
-        for (Controller controller : controllers) {
-            if (environmentPart.getCreator().equals(controller.getIdentifier())) {
-                LOGGER.debug("Found right controller for: " + environmentPart.getCreator());
-                return controller;
+        for (Controller masterController : controllers) {
+            Collection<Controller> controllers = masterController.getSubControllers().orElse(Collections.singleton(masterController));
+            for (Controller controller : controllers) {
+                if (environmentPart.getCreator().equals(controller.getIdentifier())) {
+                    LOGGER.debug("Found right controller for: " + environmentPart.getCreator());
+                    return controller;
+                }
             }
         }
         LOGGER.error("Cannot find matching creator!");

--- a/src/main/java/io/patriot_framework/network/simulator/api/manager/Manager.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/manager/Manager.java
@@ -34,6 +34,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -378,7 +380,7 @@ public class Manager {
      * @param creator creating object
      * @return
      */
-    private Device findDeviceWithCreator(Topology topology, String creator) {
+    private Device findDeviceWithCreator(Topology topology, Object creator) {
         for (Device device : topology.getRouters()) {
             if (device.getCreator().equals(creator)) {
                 return device;
@@ -466,8 +468,8 @@ public class Manager {
     }
 
     /**
-     * Finds controller by string identifier. For 'Docker' will return Docker implementation of
-     * controller.
+     * Finds controller by an object identifier. If the controller consists of multiple other controllers, it will check with them too.
+     * For 'Docker' will return Docker implementation of controller.
      * @param environmentPart part of creating environment like network, router, ...
      * @return
      */

--- a/src/main/java/io/patriot_framework/network/simulator/api/model/EnvironmentPart.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/model/EnvironmentPart.java
@@ -18,8 +18,8 @@ package io.patriot_framework.network.simulator.api.model;
 
 public interface EnvironmentPart {
     /**
-     * Returns creator identifier of env part.
+     * Returns creator identifier, can be any object, of env part.
      * @return creator of this object
      */
-    String getCreator();
+    Object getCreator();
 }

--- a/src/main/java/io/patriot_framework/network/simulator/api/model/devices/application/Application.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/model/devices/application/Application.java
@@ -33,7 +33,7 @@ public class Application implements Device {
     private String ipAddress;
     private List<Network> connectedNetworks = new ArrayList<>();
     private Map<String, String> ipAddresses = new HashMap<>();
-    private String creator;
+    private Object creator;
     private int managementPort = 0;
     public static final int DEFAULT_PORT = 8090;
 
@@ -63,7 +63,7 @@ public class Application implements Device {
      * @param name    the name
      * @param creator the creator
      */
-    public Application(String name, String creator) {
+    public Application(String name, Object creator) {
         this.name = name;
         this.creator = creator;
     }
@@ -101,7 +101,7 @@ public class Application implements Device {
     }
 
     @Override
-    public String getCreator() {
+    public Object getCreator() {
         return creator;
     }
 

--- a/src/main/java/io/patriot_framework/network/simulator/api/model/devices/router/RouterImpl.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/model/devices/router/RouterImpl.java
@@ -31,7 +31,7 @@ public class RouterImpl implements Router {
     private List<Network> connectedTopologyNetworks = new ArrayList<>();
     private String managementIP;
     private Integer managementPort = 0;
-    private String creator;
+    private Object creator;
     private boolean corner = false;
 
 
@@ -48,7 +48,7 @@ public class RouterImpl implements Router {
         connectedTopologyNetworks = new ArrayList<>();
     }
 
-    public RouterImpl(String name, String creator) {
+    public RouterImpl(String name, Object creator) {
         this.creator = creator;
         this.name = name;
     }
@@ -64,7 +64,7 @@ public class RouterImpl implements Router {
         this.networkInterfaces = networkInterfaces;
     }
 
-    public RouterImpl(String name, String creator, boolean corner) {
+    public RouterImpl(String name, Object creator, boolean corner) {
         this.name = name;
         this.creator = creator;
         this.corner = corner;
@@ -194,7 +194,7 @@ public class RouterImpl implements Router {
     }
 
     @Override
-    public String getCreator() {
+    public Object getCreator() {
         return creator;
     }
 

--- a/src/main/java/io/patriot_framework/network/simulator/api/model/network/TopologyNetwork.java
+++ b/src/main/java/io/patriot_framework/network/simulator/api/model/network/TopologyNetwork.java
@@ -33,7 +33,7 @@ public class TopologyNetwork extends Network {
     @JsonIgnore
     private Boolean internet = false;
     @JsonIgnore
-    private String creator;
+    private Object creator;
     @JsonIgnore
     private String internetInterfaceIP = null;
 
@@ -90,12 +90,12 @@ public class TopologyNetwork extends Network {
     }
 
 
-    public void setCreator(String creator) {
+    public void setCreator(Object creator) {
         this.creator = creator;
     }
 
     @Override
-    public String getCreator() {
+    public Object getCreator() {
         return creator;
     }
 

--- a/src/test/java/io/patriot_framework/network/simulator/api/BuilderTests.java
+++ b/src/test/java/io/patriot_framework/network/simulator/api/BuilderTests.java
@@ -76,6 +76,31 @@ public class BuilderTests {
     }
 
     @Test
+    public void networkBuilderObjectTest() {
+        CalculatedRouteList calcRoutes = new CalculatedRouteList();
+        NextHop nextHop = new NextHop(new RouterImpl("TestRt", 'x'), 1);
+        CalcRoute calcRoute = new CalcRoute(nextHop, 10);
+        calcRoutes.add(calcRoute);
+
+        TopologyNetwork topologyNetwork = new TopologyNetwork();
+        topologyNetwork.setCreator('x');
+        topologyNetwork.setMask(24);
+        topologyNetwork.setIPAddress("192.168.1.0");
+        topologyNetwork.setInternet(true);
+        topologyNetwork.setName("TestNet");
+        topologyNetwork.setCalcRoutes(calcRoutes);
+
+        TopologyNetwork builderNetwork = new NetworkBuilder("TestNet")
+                .withCalcRoutes(calcRoutes)
+                .withCreator('x')
+                .withInternet(true)
+                .withIP("192.168.1.0")
+                .withMask(24)
+                .build();
+        Assertions.assertEquals(builderNetwork, topologyNetwork);
+    }
+
+    @Test
     public void routerBuilderTest() {
         RouterImpl rtImpl = new RouterImpl("TestRt", "Docker", true);
         Router buildedRouter = new RouterBuilder("TestRt")
@@ -83,6 +108,17 @@ public class BuilderTests {
                 .withCreator("Docker")
                 .build();
         Assertions.assertTrue(rtImpl.equals(buildedRouter));
+
+    }
+
+    @Test
+    public void routerBuilderObjectTest() {
+        RouterImpl rtImpl = new RouterImpl("TestRt", 5, true);
+        Router buildedRouter = new RouterBuilder("TestRt")
+                .withCorner(true)
+                .withCreator(5)
+                .build();
+        Assertions.assertEquals(buildedRouter, rtImpl);
 
     }
 
@@ -117,6 +153,42 @@ public class BuilderTests {
                     .withCost(1)
                     .addRoute()
                     .buildRoutes()
+                .build();
+        Assertions.assertTrue(builderTopology.equals(topology));
+    }
+
+    @Test
+    public void topologyBuilderObjectTest() {
+        RouterImpl rtImpl = new RouterImpl("TestRt", 15, true);
+        Topology topology = new Topology(2);
+        topology.setRouters(Arrays.asList(rtImpl));
+        topology.setNetworks(prepareNetwork(rtImpl));
+
+        Topology builderTopology = new TopologyBuilder(2)
+                .withCreator("Docker")
+                .withRouters()
+                .withCorner(true)
+                .withName("TestRt")
+                .withCreator(15)
+                .createRouter()
+                .addRouters()
+                .withNetwork("TestNet1")
+                .withMask(24)
+                .withIP("192.168.1.0")
+                .withInternet(true)
+                .create()
+                .withNetwork("TestNet2")
+                .withMask(24)
+                .withIP("192.168.2.0")
+                .withInternet(false)
+                .create()
+                .withRoutes()
+                .viaRouter("TestRt")
+                .withDestNetwork(1)
+                .withSourceNetwork(0)
+                .withCost(1)
+                .addRoute()
+                .buildRoutes()
                 .build();
         Assertions.assertTrue(builderTopology.equals(topology));
     }

--- a/src/test/java/io/patriot_framework/network/simulator/api/BuilderTests.java
+++ b/src/test/java/io/patriot_framework/network/simulator/api/BuilderTests.java
@@ -45,7 +45,7 @@ public class BuilderTests {
         CalcRoute builderRoute = calcRouteBuilder.withCost(10)
                 .viaRouter(router)
                 .createCalcRoute();
-        Assertions.assertTrue(calcRoute.equals(builderRoute));
+        Assertions.assertEquals(builderRoute, calcRoute);
 
 
     }
@@ -72,7 +72,7 @@ public class BuilderTests {
                 .withIP("192.168.1.0")
                 .withMask(24)
                 .build();
-        Assertions.assertTrue(topologyNetwork.equals(builderNetwork));
+        Assertions.assertEquals(builderNetwork, topologyNetwork);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class BuilderTests {
                 .withCorner(true)
                 .withCreator("Docker")
                 .build();
-        Assertions.assertTrue(rtImpl.equals(buildedRouter));
+        Assertions.assertEquals(buildedRouter, rtImpl);
 
     }
 
@@ -154,43 +154,7 @@ public class BuilderTests {
                     .addRoute()
                     .buildRoutes()
                 .build();
-        Assertions.assertTrue(builderTopology.equals(topology));
-    }
-
-    @Test
-    public void topologyBuilderObjectTest() {
-        RouterImpl rtImpl = new RouterImpl("TestRt", 15, true);
-        Topology topology = new Topology(2);
-        topology.setRouters(Arrays.asList(rtImpl));
-        topology.setNetworks(prepareNetwork(rtImpl));
-
-        Topology builderTopology = new TopologyBuilder(2)
-                .withCreator("Docker")
-                .withRouters()
-                .withCorner(true)
-                .withName("TestRt")
-                .withCreator(15)
-                .createRouter()
-                .addRouters()
-                .withNetwork("TestNet1")
-                .withMask(24)
-                .withIP("192.168.1.0")
-                .withInternet(true)
-                .create()
-                .withNetwork("TestNet2")
-                .withMask(24)
-                .withIP("192.168.2.0")
-                .withInternet(false)
-                .create()
-                .withRoutes()
-                .viaRouter("TestRt")
-                .withDestNetwork(1)
-                .withSourceNetwork(0)
-                .withCost(1)
-                .addRoute()
-                .buildRoutes()
-                .build();
-        Assertions.assertTrue(builderTopology.equals(topology));
+        Assertions.assertEquals(topology, builderTopology);
     }
 
     private ArrayList<TopologyNetwork> prepareNetwork(Router router) {


### PR DESCRIPTION
* Change `creator` to be `Object` instead of `String`
  * Even though this change is not necessary as theoretically String could be still used, it would be more difficult to implement and less user friendly to use.
  * Should be backwards compatible in Builders as String is also an Object, Controller implementation will need changing as the interface itself has changed signatures.
  * Add test with random Objects as a creator for Builders
* Add ability for `Controller ` to contain other controllers.
  *  MultiHost controller will consist of multiple individual DockerControllers to identify individual hosts.
* Simplify asserts in BuilderTests
  
  